### PR TITLE
fix missing arguments in "RestData" call

### DIFF
--- a/custom_components/xmrpool_stat/config_flow.py
+++ b/custom_components/xmrpool_stat/config_flow.py
@@ -71,6 +71,8 @@ class XmrPoolFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     params=None,
                     data=None,
                     verify_ssl=True,
+                    encoding='UTF-8',
+                    ssl_cipher_list='python_default',
                 )
                 await rest.async_update()
                 if rest.data is None:

--- a/custom_components/xmrpool_stat/xmrpoolstat_controller.py
+++ b/custom_components/xmrpool_stat/xmrpoolstat_controller.py
@@ -45,6 +45,8 @@ class XmrPoolStatController:
             params=None,
             data=None,
             verify_ssl=True,
+            encoding='UTF-8',
+            ssl_cipher_list='python_default',
         )
         self._statData: Dict[str, Any] = None
         self._workersData: Dict[str, Dict[str, Any]] = None


### PR DESCRIPTION
This PR fixes Issue #10 , where the creation of the integrations fails due to some error in the RestData-call.